### PR TITLE
Bug/update user fix

### DIFF
--- a/src/main/java/com/bayou/converters/UserConverter.java
+++ b/src/main/java/com/bayou/converters/UserConverter.java
@@ -103,7 +103,7 @@ public class UserConverter {
         if (updatedUserState.getViewFlag() == null) {
             updatedUserState.setViewFlag(oldUserState.getViewFlag());
         }
-        
+
         if(updatedUserState.getImageId() != null) {
             if (updatedUserState.getImageId() == -1) {   //null out the image id to let the delete happen
                 updatedUserState.setImageId(null);

--- a/src/main/java/com/bayou/converters/UserConverter.java
+++ b/src/main/java/com/bayou/converters/UserConverter.java
@@ -103,11 +103,15 @@ public class UserConverter {
         if (updatedUserState.getViewFlag() == null) {
             updatedUserState.setViewFlag(oldUserState.getViewFlag());
         }
-
-        if (oldUserState.getImageId() != null && updatedUserState.getImageId() == -1) { //handles case of update to delete an image
-            updatedUserState.setImageId(null);
-        } else if (updatedUserState.getImageId() == null) {    //handles case if update that doesnt change existing image
-            updatedUserState.setImageId(oldUserState.getImageId());
+        
+        if(updatedUserState.getImageId() != null) {
+            if (updatedUserState.getImageId() == -1) {   //null out the image id to let the delete happen
+                updatedUserState.setImageId(null);
+            } //else the updateUser id is not null and not -1 then do not reassign it a value
+        } else {
+            if(updatedUserState.getImageId() == null && oldUserState.getImageId() != null) { //preserve the old image id
+                updatedUserState.setImageId(oldUserState.getImageId());
+            } //else the the old user state is null also so do nothing
         }
 
         return updatedUserState;


### PR DESCRIPTION
To Test:
- delete a user's image by setting imageId to -1. This should null out the imageId field.
- update a user's image id to an existing image in the database. The user should now have that image ID
- update a user and leave out the image id. Ensure that the previous image id, if existing, is not nulled out